### PR TITLE
fechar duas activities ao mesmo tempo para voltar a MainActivity

### DIFF
--- a/app/src/main/java/com/example/android/receitaboa/activity/EditarReceitaActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/EditarReceitaActivity.java
@@ -158,15 +158,19 @@ public class EditarReceitaActivity extends AppCompatActivity {
                         "Receita " + nome +
                                 " atualizada!",Toast.LENGTH_SHORT).show();
 
-                //encerra a activity anterior ao clicar no botão atualizar
-                VisualizarReceitaActivity.visualizacaoReceita.finish();
-
-                finish();
+                fecharAtividadeAtualAnterior(VisualizarReceitaActivity.atividadeAberta);
 
             }
 
         });
 
+    }
+
+    private void fecharAtividadeAtualAnterior(Activity ativadadeAnterior) {
+        //encerra a activity anterior ao clicar no botão atualizar
+        ativadadeAnterior.finish();
+        //encerra essa activity
+        finish();
     }
 
     @Override

--- a/app/src/main/java/com/example/android/receitaboa/activity/EditarReceitaActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/EditarReceitaActivity.java
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -157,8 +158,8 @@ public class EditarReceitaActivity extends AppCompatActivity {
                         "Receita " + nome +
                                 " atualizada!",Toast.LENGTH_SHORT).show();
 
-                Intent i = new Intent(EditarReceitaActivity.this, MainActivity.class);
-                startActivity(i);
+                //encerra a activity anterior ao clicar no botão atualizar
+                VisualizarReceitaActivity.visualizacaoReceita.finish();
 
                 finish();
 

--- a/app/src/main/java/com/example/android/receitaboa/activity/MainActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/MainActivity.java
@@ -54,11 +54,6 @@ public class MainActivity extends AppCompatActivity {
         SmartTabLayout viewPagerTab = findViewById(R.id.viewPagerTab);
         viewPagerTab.setViewPager(viewPager);
 
-        if (getIntent().getBooleanExtra("FECHAR_ACTIVITY",false)){
-            Toast.makeText(getApplicationContext(),"FECHANDO",Toast.LENGTH_SHORT).show();
-            finish();
-        }
-
     }
 
     @Override

--- a/app/src/main/java/com/example/android/receitaboa/activity/MainActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/MainActivity.java
@@ -54,6 +54,11 @@ public class MainActivity extends AppCompatActivity {
         SmartTabLayout viewPagerTab = findViewById(R.id.viewPagerTab);
         viewPagerTab.setViewPager(viewPager);
 
+        if (getIntent().getBooleanExtra("FECHAR_ACTIVITY",false)){
+            Toast.makeText(getApplicationContext(),"FECHANDO",Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
     }
 
     @Override

--- a/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaFotoActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaFotoActivity.java
@@ -141,11 +141,12 @@ public class NovaReceitaFotoActivity extends AppCompatActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
 
-                //Retorna para a main activity se o usuário decidir adicionar uma foto da receita no futuro
-                Intent i = new Intent(NovaReceitaFotoActivity.this, MainActivity.class);
-                startActivity(i);
-
                 Toast.makeText(getApplicationContext(), getApplicationContext().getString(R.string.nova_receita_adicionada), Toast.LENGTH_SHORT).show();
+
+                //encerra a activity anterior ao salvar a foto da receita
+                NovaReceitaInfoActivity.addInfoReceita.finish();
+
+                finish();
             }
         });
 
@@ -169,10 +170,7 @@ public class NovaReceitaFotoActivity extends AppCompatActivity {
                     case SELECAO_GALERIA:
                         Uri localImagemSelecionada = data.getData();
 
-                        fotoReceita = MediaStore.Images.Media.getBitmap(getContentResolver(), localImagemSelecionada); //DEPRECIADO no API 29 MAS FUNCIONA A PARTIR DO API 28
-
-                        //ImageDecoder.Source imgSource = ImageDecoder.createSource(getContentResolver(), localImagemSelecionada); //Primeiro cria a source
-                        //fotoReceita = ImageDecoder.decodeBitmap(imgSource); //SEGUNDO: converte ImageDecoder.Source -> Bitmap //PARA O API 29 (PROBLEMA: SÓ FUNCIONA EM APARELHOS COM API MIN 28 - PIE - ANDROID 9)
+                        fotoReceita = MediaStore.Images.Media.getBitmap(getContentResolver(), localImagemSelecionada);
 
                         break;
                     case SELECAO_CAMERA:
@@ -223,8 +221,6 @@ public class NovaReceitaFotoActivity extends AppCompatActivity {
 
                                     result.addOnSuccessListener(new OnSuccessListener<Uri>() {
 
-                                        ///////////////////////////////
-
                                         @Override
                                         public void onSuccess(Uri uri) {
 
@@ -273,11 +269,13 @@ public class NovaReceitaFotoActivity extends AppCompatActivity {
                     //recupera todos os dados não alterados e os reescreve no FirebaseDatabase e também recupera o caminho da foto alterada e a atualiza no FirebaseDatabase
                     minhaReceita.adicionarUrlFotoFirebaseDb(idReceitaRecuperada);
 
-                    //Retorna para a main activity após o usuário selecionar uma foto
-                    Intent i = new Intent(NovaReceitaFotoActivity.this, MainActivity.class);
-                    startActivity(i);
-
                     mensagemFotoAdicionada();
+
+                    //encerra a activity anterior ao salvar a foto da receita
+                    NovaReceitaInfoActivity.addInfoReceita.finish();
+
+                    finish();
+
                 }
             }
 

--- a/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
@@ -43,7 +43,7 @@ public class NovaReceitaInfoActivity extends AppCompatActivity {
     private StorageReference storageRef;
     private String identificadorChef;
 
-    public static Activity addInfoReceita;
+    public static Activity atividadeAberta;
 
 
     @Override
@@ -52,7 +52,7 @@ public class NovaReceitaInfoActivity extends AppCompatActivity {
         setContentView(R.layout.activity_nova_receita_info);
 
         //referenciando a Activity
-        addInfoReceita = this;
+        atividadeAberta = this;
 
         //Configurações iniciais
         storageRef = ConfiguracaoFirebase.getFirebaseStorage();

--- a/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
@@ -15,20 +15,17 @@
  */
 package com.example.android.receitaboa.activity;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.android.receitaboa.R;
 import com.example.android.receitaboa.helper.ConfiguracaoFirebase;
-import com.example.android.receitaboa.helper.Permissao;
 import com.example.android.receitaboa.helper.UsuarioFirebaseAuth;
 import com.example.android.receitaboa.model.Receitas;
 import com.google.firebase.storage.StorageReference;
@@ -82,6 +79,7 @@ public class NovaReceitaInfoActivity extends AppCompatActivity {
         minhasReceitas.salvarMinhaReceitaFirebaseDb();
 
         Intent i = new Intent(NovaReceitaInfoActivity.this, NovaReceitaFotoActivity.class);
+        i.putExtra("idReceita",minhasReceitas.getIdReceita());
         startActivity(i);
 
     }

--- a/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/NovaReceitaInfoActivity.java
@@ -16,6 +16,7 @@
 package com.example.android.receitaboa.activity;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -45,11 +46,16 @@ public class NovaReceitaInfoActivity extends AppCompatActivity {
     private StorageReference storageRef;
     private String identificadorChef;
 
+    public static Activity addInfoReceita;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_nova_receita_info);
+
+        //referenciando a Activity
+        addInfoReceita = this;
 
         //Configurações iniciais
         storageRef = ConfiguracaoFirebase.getFirebaseStorage();

--- a/app/src/main/java/com/example/android/receitaboa/activity/VisualizarReceitaActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/VisualizarReceitaActivity.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -39,6 +40,7 @@ public class VisualizarReceitaActivity extends AppCompatActivity {
     private DatabaseReference receitasRef;
     private DatabaseReference receitasChefRef;
 
+    public static Activity visualizacaoReceita;
 
     private Receitas receitaClicada;
 
@@ -54,6 +56,8 @@ public class VisualizarReceitaActivity extends AppCompatActivity {
         idChefLogado = UsuarioFirebaseAuth.getIdentificadorChefAuth(); //id do chef logado (emailAuth convertido em base64)
         firebaseDbRef = ConfiguracaoFirebase.getFirebaseDatabase();
         receitasRef = firebaseDbRef.child("receitas");
+
+        visualizacaoReceita = this;
 
         //Configurar referência receitas do chef logado
         receitasChefRef = receitasRef
@@ -100,6 +104,7 @@ public class VisualizarReceitaActivity extends AppCompatActivity {
             }
 
         }
+
     }
 
     @Override

--- a/app/src/main/java/com/example/android/receitaboa/activity/VisualizarReceitaActivity.java
+++ b/app/src/main/java/com/example/android/receitaboa/activity/VisualizarReceitaActivity.java
@@ -6,7 +6,6 @@ import androidx.appcompat.widget.Toolbar;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
@@ -40,7 +39,7 @@ public class VisualizarReceitaActivity extends AppCompatActivity {
     private DatabaseReference receitasRef;
     private DatabaseReference receitasChefRef;
 
-    public static Activity visualizacaoReceita;
+    public static Activity atividadeAberta;
 
     private Receitas receitaClicada;
 
@@ -57,7 +56,7 @@ public class VisualizarReceitaActivity extends AppCompatActivity {
         firebaseDbRef = ConfiguracaoFirebase.getFirebaseDatabase();
         receitasRef = firebaseDbRef.child("receitas");
 
-        visualizacaoReceita = this;
+        atividadeAberta = this;
 
         //Configurar referência receitas do chef logado
         receitasChefRef = receitasRef

--- a/app/src/main/java/com/example/android/receitaboa/model/Receitas.java
+++ b/app/src/main/java/com/example/android/receitaboa/model/Receitas.java
@@ -38,6 +38,7 @@ public class Receitas implements Serializable {
 
         //Cria um id para a nova receita criada pelo chef
         String identificadorReceita = receitasRef.push().getKey();
+
         setIdReceita(identificadorReceita);
     }
 


### PR DESCRIPTION
… uma foto na tela "nova receita foto" e ao clicar em atualizar na tela "editar receita", a intent que levava o usuário para MainActivity foi substituída por um método que encerra a activity "nova receita info" e a activity "nova receita foto" ao mesmo tempo. Mesmo procedimento foi adotado para tela editar receita. Ao clicar em atualizar as activities "editar receita" e "visualizar receita" são encerradas. Através do método finish.

Resolvido o problema de activities antigas e fora de ordem aparecerem após o usuário clicar no botão voltar do celular.